### PR TITLE
ci: rewrite release workflow with multi-target matrix and cargo publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,62 +6,115 @@ on:
       - "v*.*.*"
       - "test-release-*"
 
+permissions:
+  contents: write
+
 jobs:
   build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu	
-            lib: /usr/lib/aarch64-linux-gnu
-          - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            lib: /usr/lib/x86_64-linux-gnu
-          # - os: macos-latest
-          #   target: aarch64-apple-darwin
-          # - os: macos-latest
-          #   target: x86_64-apple-darwin
-
-    # runs-on: ${{ matrix.os }}
-    runs-on: ubuntu-latest
+            use-cross: false
+          # aarch64 requires cross-compilation since the host is x86_64. We use cross (Docker-based)
+          # instead of plain cargo because cross's images ship with a pre-built OpenSSL for each
+          # target, eliminating the need to manually set up a cross-compiled OpenSSL environment
+          # that git2 depends on.
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            use-cross: true
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            use-cross: false
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            use-cross: false
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            use-cross: false
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/cache@v5
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: |
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      # git2 depends on OpenSSL. For native Linux builds we install it explicitly; cross builds
+      # resolve it inside the container; macOS and Windows toolchains handle it automatically.
+      - name: Install system dependencies
+        if: runner.os == 'Linux' && !matrix.use-cross
+        run: |
           sudo apt-get update
-          sudo apt-get install -y libssl-dev libssl-dev:arm64 pkg-config build-essential qemu gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-          ls -lah /usr/lib/aarch64-linux-gnu
-      # - run: sudo apt-get install libssl-dev pkg-config
-      # - run: sudo apt-get install g++-arm-linux-gnueabihf
-      #   if: matrix.os == 'ubuntu-latest'
-      # - uses: actions-rs/toolchain@v1
-      #   with:
-      #     toolchain: stable
-      #     target: ${{ matrix.target }}
-      #     override: true
-      # - uses: actions-rs/cargo@v1
-      #   with:
-      #     use-cross: true
-      #     command: build
-      #     args: --release --target ${{ matrix.target }} --all-features
-      - run: rustup target add ${{ matrix.target }}
-      - run: cargo build --release --target ${{ matrix.target }}
-        env:
-          OPENSSL_LIB_DIR: ${{ matrix.lib }}
-          OPENSSL_INCLUDE_DIR: /usr/include/openssl
-      - uses: softprops/action-gh-release@v3
+          sudo apt-get install -y libssl-dev pkg-config
+
+      - uses: taiki-e/install-action@v2
+        if: matrix.use-cross
+        with:
+          tool: cross
+
+      - name: Build (native)
+        if: "!matrix.use-cross"
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Build (cross)
+        if: matrix.use-cross
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Strip binary (Linux x86_64)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: strip target/${{ matrix.target }}/release/git-branch-status
+
+      - name: Strip binary (Linux aarch64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get install -y binutils-aarch64-linux-gnu
+          aarch64-linux-gnu-strip target/${{ matrix.target }}/release/git-branch-status
+
+      - name: Strip binary (macOS)
+        if: runner.os == 'macOS'
+        run: strip target/${{ matrix.target }}/release/git-branch-status
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          archive="git-branch-status-${{ github.ref_name }}-${{ matrix.target }}.tar.gz"
+          tar czvf "$archive" -C target/${{ matrix.target }}/release git-branch-status
+          shasum -a 256 "$archive" > "$archive.sha256"
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $archive = "git-branch-status-${{ github.ref_name }}-${{ matrix.target }}.zip"
+          Compress-Archive -Path "target\${{ matrix.target }}\release\git-branch-status.exe" -DestinationPath $archive
+          (Get-FileHash $archive -Algorithm SHA256).Hash | Out-File -FilePath "$archive.sha256" -NoNewline
+
+      - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
           files: |
-            README.md
-            LICENSE
-            target/**/release/git-branch-status
+            git-branch-status-*.tar.gz
+            git-branch-status-*.tar.gz.sha256
+            git-branch-status-*.zip
+            git-branch-status-*.zip.sha256
+
+  publish-cargo:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- Add macOS (x86_64/aarch64) and Windows (x86_64) build targets alongside the existing Linux targets
- Use `cross` for Linux aarch64 cross-compilation to avoid manually configuring a cross-compiled OpenSSL environment that `git2` depends on; cross's Docker images ship with OpenSSL pre-built for each target
- Replace the old `actions-rs/*` and manual OpenSSL path setup with `dtolnay/rust-toolchain` + `Swatinem/rust-cache@v2`, consistent with the CI workflow
- Package each binary as `.tar.gz` (Unix) or `.zip` (Windows) with a `.sha256` checksum and upload to the GitHub release
- Add a `publish-cargo` job that runs only on `v*.*.*` tags (skipped for `test-release-*`)

## Test plan

- [ ] Push a `test-release-*` tag and verify all 5 build jobs succeed and artifacts appear on the release page
- [ ] Confirm `publish-cargo` job is skipped for `test-release-*` tags
- [ ] Push a `v*.*.*` tag and verify `publish-cargo` runs after all build jobs complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)