### PR TITLE
fix: explicitly install Rust target with rustup in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
+
+      # Install the target explicitly instead of relying on dtolnay/rust-toolchain's `targets`
+      # parameter, which does not reliably install cross-compilation targets on macOS ARM64
+      # runners (e.g. x86_64-apple-darwin on macos-latest). Not needed for cross builds since
+      # cross compiles inside a Docker container that manages its own toolchain.
+      - name: Add Rust target
+        if: "!matrix.use-cross"
+        run: rustup target add ${{ matrix.target }}
 
       # git2 depends on OpenSSL. For native Linux builds we install it explicitly; cross builds
       # resolve it inside the container; macOS and Windows toolchains handle it automatically.


### PR DESCRIPTION
## Problem

`x86_64-apple-darwin` build was failing on `macos-latest` with:

```
error[E0463]: can't find crate for `core`
  = note: the `x86_64-apple-darwin` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-apple-darwin`
```

`macos-latest` is now an ARM64 runner (M-series), so the default Rust target is `aarch64-apple-darwin`. The `targets` parameter of `dtolnay/rust-toolchain` did not reliably install `x86_64-apple-darwin` in this environment.

## Fix

Replace the `targets` parameter with an explicit `rustup target add ${{ matrix.target }}` step. This runs only for native builds (skipped for `cross`-based builds, which compile inside a Docker container that manages its own toolchain).

## Test plan

- [ ] Push a `test-release-*` tag and verify all 5 build jobs complete successfully, including `x86_64-apple-darwin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)