### PR TITLE
fix: remove generate_release_notes from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,19 @@ permissions:
   contents: write
 
 jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      # Create the release once here so that generate_release_notes runs exactly once.
+      # Each build job then uploads its artifact to the already-created release without
+      # regenerating the notes, which would cause them to be overwritten on every upload.
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+
   build:
     name: Build ${{ matrix.target }}
+    needs: create-release
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -105,7 +116,6 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
           files: |
             git-branch-status-*.tar.gz
             git-branch-status-*.tar.gz.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,19 +10,8 @@ permissions:
   contents: write
 
 jobs:
-  create-release:
-    runs-on: ubuntu-latest
-    steps:
-      # Create the release once here so that generate_release_notes runs exactly once.
-      # Each build job then uploads its artifact to the already-created release without
-      # regenerating the notes, which would cause them to be overwritten on every upload.
-      - uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-
   build:
     name: Build ${{ matrix.target }}
-    needs: create-release
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
## Problem

`generate_release_notes: true` was set in each matrix build job, causing all 5 jobs to race and overwrite each other's release notes on every artifact upload.

## Fix

Remove `generate_release_notes` entirely. Release notes are managed manually via CHANGELOG.md — written to the GitHub release body in the UI when creating the tag and release. The workflow's only responsibility is uploading build artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)