### PR TITLE
fix: add description and license metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ name = "git-branch-status"
 version = "0.1.0"
 authors = ["Akiomi Kamakura <akiomik@gmail.com>"]
 edition = "2024"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+description = "A command line tool for displaying git branch colored by status"
+license = "Apache-2.0"
 
 [dependencies]
 git2 = "0.21"


### PR DESCRIPTION
## Summary

- Add `description` field: `"A command line tool for displaying git branch colored by status"`
- Add `license` field: `"Apache-2.0"` (matches the `LICENSE` file in the repository)

These fields are required by crates.io and were causing a publish error:
```
missing or empty metadata fields: description, license
```

## Test plan

- [ ] Run `cargo package --dry-run` to verify the package can be built without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)