### PR TITLE
fix: exit quietly instead of panicking on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Exit quietly instead of panicking when the branch name or status cannot be
+  retrieved, so the prompt is not polluted with a panic message
+
 ## [0.1.0] - 2026-06-29
 
 ### Changed

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,12 +43,12 @@ fn main() {
 
     let branch = match repo.branch_name() {
         Ok(branch) => branch,
-        Err(e) => panic!("failed to get branch: {}", e),
+        Err(_) => std::process::exit(1),
     };
 
     let status = match repo.branch_status() {
         Ok(status) => status,
-        Err(e) => panic!("failed to get branch status: {}", e),
+        Err(_) => std::process::exit(1),
     };
 
     let mode = matches.get_one::<String>("mode").unwrap().as_str();


### PR DESCRIPTION
## Summary

This tool is meant to be embedded in the shell prompt (e.g. zsh's `RPROMPT`). Previously, when `branch_name()` or `branch_status()` failed, it called `panic!`, dumping a multi-line panic message directly into the prompt.

This changes those error paths to exit with status `1` silently, matching the existing handling of `Repository::discover` failures in `main.rs`.

## Changes

- `src/main.rs`: replace `panic!` with `std::process::exit(1)` for branch name / status retrieval failures
- `CHANGELOG.md`: add an entry under `Unreleased` / `Fixed`

## Test plan

- `cargo fmt --check`
- `cargo build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)