### PR TITLE
refactor: drop unreachable mode match arm

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
                 BranchStatus::Conflicted => print!("%F{{red}}{}%f", branch),
             };
         }
-        "stdout" => {
+        _ => {
             match status {
                 BranchStatus::NotChanged => print!("{}", Green.paint(branch)),
                 BranchStatus::Staged => print!("{}", Yellow.paint(branch)),
@@ -69,6 +69,5 @@ fn main() {
                 BranchStatus::Conflicted => print!("{}", Red.paint(branch)),
             };
         }
-        _ => panic!("unsupported mode is specified: {}", mode),
     };
 }


### PR DESCRIPTION
## Summary

The `mode` argument is restricted to `"zsh"` or `"stdout"` by clap's `value_parser(["zsh", "stdout"])`, so the `_ => panic!("unsupported mode ...")` arm in `main.rs` was unreachable dead code.

This folds the `"stdout"` branch into the catch-all `_` arm, removing the panic. It also aligns with clap's `default_value("stdout")`, so the behavior is unchanged.

## Test plan

- `cargo fmt --check`
- `cargo clippy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)