### PR TITLE
refactor: derive version and author from Cargo.toml

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,8 @@ use git_branch_status::repository_ext::RepositoryExt;
 
 fn main() {
     let matches = Command::new("git-branch-status")
-        .version("0.1.0")
-        .author("Akiomi Kamakura <akiomik@gmail.com>")
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
         .about("Show git branch name colored by status")
         .arg(
             Arg::new("mode")


### PR DESCRIPTION
## Summary

The CLI `version` and `author` strings were hard-coded in `main.rs`, duplicating the metadata already declared in `Cargo.toml` (e.g. the version `0.1.0` had to be kept in sync manually).

This replaces them with the `CARGO_PKG_VERSION` and `CARGO_PKG_AUTHORS` environment variables that Cargo provides at compile time, so `Cargo.toml` becomes the single source of truth.

## Test plan

- `cargo fmt --check`
- `cargo build`
- `git-branch-status --version` → `git-branch-status 0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)