### PR TITLE
test: add hyperfine-based benchmark for git-branch-status

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ format = " on $output"
 
 ## Benchmark
 
-Run `./scripts/bench.sh`. `git-branch-status` is about 5x faster than `vcs_info` on M1 MacBook Pro (2021).
+### Against vcs_info
+
+Run `./scripts/bench-vcs-info.sh`. `git-branch-status` is about 5x faster than `vcs_info` on M1 MacBook Pro (2021).
 
 ```sh
-❯ ./scripts/bench.sh
+❯ ./scripts/bench-vcs-info.sh
 Setup vcs_info...done!
 Setup git-branch-status...done!
 
@@ -57,4 +59,19 @@ Elapsed time: 2029ms
 Run './target/release/git-branch-status --mode zsh' 100 times
 ....................................................................................................done!
 Elapsed time: 404ms
+```
+
+### git-branch-status on its own
+
+Run `./scripts/bench.sh` to benchmark `git-branch-status` alone with
+[hyperfine](https://github.com/sharkdp/hyperfine). This is handy when working on
+performance, since it reports the mean, standard deviation, and min/max across
+many runs.
+
+```sh
+❯ ./scripts/bench.sh
+Building git-branch-status...
+Benchmark 1: ./target/release/git-branch-status --mode zsh
+  Time (mean ± σ):       8.2 ms ±   0.4 ms    [User: 2.8 ms, System: 2.9 ms]
+  Range (min … max):     7.7 ms …  10.7 ms    327 runs
 ```

--- a/scripts/bench-vcs-info.sh
+++ b/scripts/bench-vcs-info.sh
@@ -1,0 +1,56 @@
+#!/bin/zsh
+
+# Copyright 2021 Akiomi Kamakura
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+DATE="gdate"
+GIT_BRANCH_STATUS="./target/release/git-branch-status"
+
+function timestamp() {
+  echo $(($($DATE +%s%0N)/1000000))
+}
+
+function bench() {
+  cmd="$1"
+  n="$2"
+
+  echo "Run '$cmd' $n times"
+  start=`timestamp`
+  for i in `seq $n`; do
+    echo -n "."
+    eval "$cmd" > /dev/null
+  done
+  echo "done!"
+  stop=`timestamp`
+  echo "Elapsed time: $(($stop-$start))ms"
+}
+
+echo -n 'Setup vcs_info'
+autoload -Uz vcs_info
+zstyle ':vcs_info:git:*' check-for-changes true
+zstyle ':vcs_info:git:*' stagedstr     '%F{yellow}'           # %c
+zstyle ':vcs_info:git:*' unstagedstr   '%F{red}'              # %u
+zstyle ':vcs_info:*'     formats       '%F{green}%c%u%b%f'    # %b: branch
+zstyle ':vcs_info:*'     actionformats '%F{green}%c%u%b:%a%f' # %a: action
+echo '...done!'
+
+echo -n 'Setup git-branch-status'
+cargo build --release > /dev/null 2>&1
+echo '...done!'
+
+echo
+bench 'vcs_info; echo $vcs_info_msg_0_' 100
+echo
+bench "$GIT_BRANCH_STATUS --mode zsh" 100

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/sh
 
 # Copyright 2021 Akiomi Kamakura
 #
@@ -14,43 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Benchmark git-branch-status on its own using hyperfine. Use this when
+# working on performance to compare before/after with reliable statistics.
+# For a comparison against zsh's vcs_info, see ./scripts/bench-vcs-info.sh.
 
-DATE="gdate"
+set -e
+
 GIT_BRANCH_STATUS="./target/release/git-branch-status"
 
-function timestamp() {
-  echo $(($($DATE +%s%0N)/1000000))
-}
-
-function bench() {
-  cmd="$1"
-  n="$2"
-
-  echo "Run '$cmd' $n times"
-  start=`timestamp`
-  for i in `seq $n`; do
-    echo -n "."
-    eval "$cmd" > /dev/null
-  done
-  echo "done!"
-  stop=`timestamp`
-  echo "Elapsed time: $(($stop-$start))ms"
-}
-
-echo -n 'Setup vcs_info'
-autoload -Uz vcs_info
-zstyle ':vcs_info:git:*' check-for-changes true
-zstyle ':vcs_info:git:*' stagedstr     '%F{yellow}'           # %c
-zstyle ':vcs_info:git:*' unstagedstr   '%F{red}'              # %u
-zstyle ':vcs_info:*'     formats       '%F{green}%c%u%b%f'    # %b: branch
-zstyle ':vcs_info:*'     actionformats '%F{green}%c%u%b:%a%f' # %a: action
-echo '...done!'
-
-echo -n 'Setup git-branch-status'
+echo "Building git-branch-status..."
 cargo build --release > /dev/null 2>&1
-echo '...done!'
 
-echo
-bench 'vcs_info; echo $vcs_info_msg_0_' 100
-echo
-bench "$GIT_BRANCH_STATUS --mode zsh" 100
+hyperfine --warmup 10 --shell=none "$GIT_BRANCH_STATUS --mode zsh"


### PR DESCRIPTION
## Summary

The existing benchmark used `gdate` timestamps and a fixed loop, with no warmup, outlier handling, or statistics, which made before/after comparisons unreliable — exactly what we need for upcoming performance work.

- Add a new `scripts/bench.sh` that benchmarks `git-branch-status` on its own using [hyperfine](https://github.com/sharkdp/hyperfine), reporting mean / standard deviation / min-max across many runs.
- Rename the previous script to `scripts/bench-vcs-info.sh` so the comparison against zsh's `vcs_info` (and the "~5x faster" claim) is preserved.
- Update the README `Benchmark` section to document both scripts.

This is tooling only and does not affect the shipped binary, so there is no CHANGELOG entry.

## Test plan

- `sh scripts/bench.sh` runs and reports hyperfine statistics

🤖 Generated with [Claude Code](https://claude.com/claude-code)