### PR TITLE
test: cover branch_name resolution for repository states

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,10 +118,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
 
 [[package]]
 name = "git-branch-status"
@@ -130,6 +157,7 @@ dependencies = [
  "ansi_term",
  "clap",
  "git2",
+ "tempfile",
 ]
 
 [[package]]
@@ -161,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
@@ -190,6 +218,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,10 +233,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "shlex"
@@ -215,6 +274,19 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ license = "Apache-2.0"
 git2 = "0.21"
 ansi_term = "0.12"
 clap = "4.6.1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/repository_ext.rs
+++ b/src/repository_ext.rs
@@ -155,3 +155,97 @@ impl RepositoryExt for Repository {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RepositoryExt;
+    use git2::{Oid, Repository, RepositoryInitOptions, RepositoryState, Signature};
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn init_repo() -> (TempDir, Repository) {
+        let dir = TempDir::new().unwrap();
+        let mut opts = RepositoryInitOptions::new();
+        opts.initial_head("main");
+        let repo = Repository::init_opts(dir.path(), &opts).unwrap();
+        (dir, repo)
+    }
+
+    fn commit(repo: &Repository, message: &str) -> Oid {
+        let sig = Signature::now("tester", "tester@example.com").unwrap();
+        let tree_id = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let parents = match repo.head() {
+            Ok(head) => vec![head.peel_to_commit().unwrap()],
+            Err(_) => vec![],
+        };
+        let parent_refs: Vec<&_> = parents.iter().collect();
+        repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parent_refs)
+            .unwrap()
+    }
+
+    #[test]
+    fn branch_name_returns_branch_on_unborn_branch() {
+        let (_dir, repo) = init_repo();
+        assert_eq!(repo.branch_name().unwrap(), "main");
+    }
+
+    #[test]
+    fn branch_name_returns_branch_on_normal_branch() {
+        let (_dir, repo) = init_repo();
+        commit(&repo, "initial");
+        assert_eq!(repo.branch_name().unwrap(), "main");
+    }
+
+    #[test]
+    fn branch_name_returns_short_hash_on_detached_head() {
+        let (_dir, repo) = init_repo();
+        let oid = commit(&repo, "initial");
+        repo.set_head_detached(oid).unwrap();
+        let short = repo.to_short_oid(oid).unwrap().unwrap();
+        assert_eq!(repo.branch_name().unwrap(), short);
+    }
+
+    #[test]
+    fn unborn_branch_name_returns_symbolic_target() {
+        let (_dir, repo) = init_repo();
+        assert_eq!(repo.unborn_branch_name().unwrap(), Some("main".to_string()));
+    }
+
+    #[test]
+    fn rebase_head_name_returns_none_when_not_rebasing() {
+        let (_dir, repo) = init_repo();
+        assert_eq!(repo.rebase_head_name(RepositoryState::Clean).unwrap(), None);
+    }
+
+    #[test]
+    fn rebase_head_name_reads_apply_backend_head_name() {
+        let (_dir, repo) = init_repo();
+        let rebase_dir = repo.path().join("rebase-apply");
+        fs::create_dir_all(&rebase_dir).unwrap();
+        fs::write(rebase_dir.join("head-name"), "refs/heads/feature\n").unwrap();
+
+        assert_eq!(
+            repo.rebase_head_name(RepositoryState::Rebase).unwrap(),
+            Some("feature".to_string())
+        );
+    }
+
+    #[test]
+    fn rebase_head_name_reads_merge_backend_head_name() {
+        let (_dir, repo) = init_repo();
+        let rebase_dir = repo.path().join("rebase-merge");
+        fs::create_dir_all(&rebase_dir).unwrap();
+        fs::write(rebase_dir.join("head-name"), "refs/heads/feature\n").unwrap();
+
+        assert_eq!(
+            repo.rebase_head_name(RepositoryState::RebaseInteractive)
+                .unwrap(),
+            Some("feature".to_string())
+        );
+        assert_eq!(
+            repo.rebase_head_name(RepositoryState::RebaseMerge).unwrap(),
+            Some("feature".to_string())
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Add regression tests for the branch name resolution fixed in #194. They build throwaway repositories with `git2` itself — **no `git` CLI is spawned** and no actual rebase is executed; the rebase cases only write the `head-name` state files.

Covered:

- unborn branch → resolves to the branch name (`main`)
- normal branch → resolves to the branch name (`main`)
- detached HEAD → resolves to the short commit hash
- `rebase_head_name` reads `head-name` for both the apply (`rebase-apply/`) and merge (`rebase-merge/`) backends, and returns `None` when no rebase is in progress
- `unborn_branch_name` returns the symbolic HEAD target

`tempfile` is added as a dev-dependency for the temporary repositories.

## Test plan

- `cargo test` → 7 passed
- `cargo fmt --check`
- `cargo clippy --all-targets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)