### PR TITLE
fix: show tag name when HEAD is detached at a tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repository without any commits yet)
 - Show the original branch name during an apply-backend rebase, instead of the
   detached commit hash
+- Show the tag name when HEAD is detached at a tag, instead of the commit hash
 
 ## [0.1.0] - 2026-06-29
 

--- a/src/repository_ext.rs
+++ b/src/repository_ext.rs
@@ -14,7 +14,10 @@
 
 use std::fs;
 
-use git2::{Error, ErrorCode, Oid, Repository, RepositoryState, StatusOptions};
+use git2::{
+    DescribeFormatOptions, DescribeOptions, Error, ErrorCode, Oid, Repository, RepositoryState,
+    StatusOptions,
+};
 
 use crate::branch_status::BranchStatus;
 use crate::status_entry_ext::StatusEntryExt;
@@ -25,6 +28,7 @@ pub trait RepositoryExt {
     fn branch_status(&self) -> Result<BranchStatus, Error>;
     fn rebase_head_name(&self, state: RepositoryState) -> Result<Option<String>, Error>;
     fn unborn_branch_name(&self) -> Result<Option<String>, Error>;
+    fn tag_name(&self) -> Result<Option<String>, Error>;
     fn to_short_oid(&self, oid: Oid) -> Result<Option<String>, Error>;
 }
 
@@ -63,14 +67,19 @@ impl RepositoryExt for Repository {
         let branch = if let Some(name) = self.rebase_head_name(state)? {
             name
         } else if detached {
-            let oid = head.as_ref().and_then(|h| h.target());
-            let short = match oid.map(|oid| self.to_short_oid(oid)) {
-                Some(Ok(id)) => id,
-                Some(Err(e)) => return Err(e),
-                None => None,
-            };
+            // Prefer a tag pointing at HEAD, falling back to the short hash.
+            if let Some(tag) = self.tag_name()? {
+                tag
+            } else {
+                let oid = head.as_ref().and_then(|h| h.target());
+                let short = match oid.map(|oid| self.to_short_oid(oid)) {
+                    Some(Ok(id)) => id,
+                    Some(Err(e)) => return Err(e),
+                    None => None,
+                };
 
-            short.unwrap_or_else(|| "HEAD (detached)".to_string())
+                short.unwrap_or_else(|| "HEAD (detached)".to_string())
+            }
         } else if let Some(name) = head.as_ref().and_then(|h| h.shorthand().ok()) {
             name.to_string()
         } else {
@@ -147,6 +156,24 @@ impl RepositoryExt for Repository {
         }))
     }
 
+    fn tag_name(&self) -> Result<Option<String>, Error> {
+        // `max_candidates_tags(0)` makes this behave like `git describe
+        // --exact-match`: it resolves only a tag that points at HEAD and
+        // errors otherwise, which we treat as "no tag".
+        let mut opts = DescribeOptions::new();
+        opts.describe_tags().max_candidates_tags(0);
+
+        let describe = match self.describe(&opts) {
+            Ok(describe) => describe,
+            Err(_) => return Ok(None),
+        };
+
+        let mut format = DescribeFormatOptions::new();
+        format.abbreviated_size(0);
+
+        Ok(describe.format(Some(&format)).ok())
+    }
+
     fn to_short_oid(&self, oid: Oid) -> Result<Option<String>, Error> {
         let object = self.find_object(oid, None)?;
         match object.short_id() {
@@ -204,6 +231,34 @@ mod tests {
         repo.set_head_detached(oid).unwrap();
         let short = repo.to_short_oid(oid).unwrap().unwrap();
         assert_eq!(repo.branch_name().unwrap(), short);
+    }
+
+    #[test]
+    fn branch_name_returns_tag_on_detached_head_at_tag() {
+        let (_dir, repo) = init_repo();
+        let oid = commit(&repo, "initial");
+        let object = repo.find_object(oid, None).unwrap();
+        repo.tag_lightweight("v1.0.0", &object, false).unwrap();
+        repo.set_head_detached(oid).unwrap();
+        assert_eq!(repo.branch_name().unwrap(), "v1.0.0");
+    }
+
+    #[test]
+    fn tag_name_returns_none_without_tag() {
+        let (_dir, repo) = init_repo();
+        let oid = commit(&repo, "initial");
+        repo.set_head_detached(oid).unwrap();
+        assert_eq!(repo.tag_name().unwrap(), None);
+    }
+
+    #[test]
+    fn tag_name_returns_tag_at_head() {
+        let (_dir, repo) = init_repo();
+        let oid = commit(&repo, "initial");
+        let object = repo.find_object(oid, None).unwrap();
+        repo.tag_lightweight("v1.0.0", &object, false).unwrap();
+        repo.set_head_detached(oid).unwrap();
+        assert_eq!(repo.tag_name().unwrap(), Some("v1.0.0".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When HEAD is detached at a tagged commit (e.g. after `git checkout v1.0.0`), the tool printed the short commit hash instead of the tag name.

`branch_name` now prefers a tag pointing at HEAD over the short hash. The new `tag_name` helper uses git2's describe with `max_candidates_tags(0)` — the equivalent of `git describe --exact-match` — so it resolves only a tag that points exactly at HEAD and otherwise reports "no tag".

- Both lightweight and annotated tags are handled.
- A detached HEAD without a tag still falls back to the short hash.

This PR includes regression tests (the test harness from #195 is already on `main`).

## Verification

Manually exercised with throwaway repositories:

| Case | Before | After |
|---|---|---|
| detached at annotated tag `v1.0.0` | `62f170e` | `v1.0.0` |
| detached at lightweight tag `v1.5.0` | hash | `v1.5.0` |
| detached at untagged commit | `4ea2a87` | `4ea2a87` (unchanged) |
| normal branch | `main` | `main` (unchanged) |

## Test plan

- `cargo test` → 10 passed
- `cargo fmt --check`
- `cargo clippy --all-targets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)