### PR TITLE
docs: document starship command_timeout and simplify the when check

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ RPROMPT='$(git branch-status --mode zsh)'
 
 Add the following to `~/.config/starship.toml`:
 
-```sh
+```toml
+command_timeout = 1000
+
 format = """
 $directory\
 $custom\
@@ -37,9 +39,15 @@ $character"""
 
 [custom.branchstatus]
 command = "git branch-status --mode zsh"
-when = "[[ -d .git ]] || [[ `git rev-parse --git-dir > /dev/null 2>&1; echo $?` -eq 0 ]]"
+when = "git rev-parse --is-inside-work-tree 2>/dev/null"
 format = " on $output"
 ```
+
+Starship aborts any custom command that runs longer than
+[`command_timeout`](https://starship.rs/config/#prompt) (500ms by default) and
+shows a warning instead of its output. In large repositories `git-branch-status`
+can take longer than that, so raise `command_timeout` (e.g. to 1000ms) if the
+module disappears or you see a timeout warning.
 
 ## Benchmark
 


### PR DESCRIPTION
## Summary

- Document starship's `command_timeout`: in large repositories `git-branch-status` can exceed the default 500ms, which makes starship drop the custom module and print a warning. The README now shows `command_timeout = 1000` and explains when to raise it.
- Simplify the custom module's `when` condition from the verbose `[[ -d .git ]] || [[ \`git rev-parse ...\` ]]` to the idiomatic `git rev-parse --is-inside-work-tree 2>/dev/null`, which also spawns git only once.
- Use a ```toml fence for the starship snippet (it is TOML, not shell).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)