### PR TITLE
ci: publish to crates.io via Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,10 +116,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
+    # Trusted Publishing: the OIDC token is exchanged for a short-lived
+    # crates.io token, so no long-lived CARGO_REGISTRY_TOKEN secret is needed.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Summary

Switch the `publish-cargo` job from the long-lived `CARGO_REGISTRY_TOKEN` secret to crates.io [Trusted Publishing](https://crates.io/docs/trusted-publishing) (OIDC).

- Grant the job `id-token: write` (and `contents: read`) so it can request a GitHub OIDC token.
- Use `rust-lang/crates-io-auth-action@v1` to exchange that token for a short-lived crates.io token, passed to `cargo publish` as `CARGO_REGISTRY_TOKEN`.

The Trusted Publisher is already configured on crates.io for this repo's `release.yml` workflow (no environment). The `if: startsWith(github.ref, 'refs/tags/v')` guard is unchanged, so `test-release-*` tags still don't publish.

## Follow-up

Once this is merged and a release confirms publishing works, the `CARGO_REGISTRY_TOKEN` repository secret can be deleted from **Settings → Secrets and variables → Actions** (it's no longer referenced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)