### PR TITLE
docs: document crates.io and prebuilt binary installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ A command line tool for displaying git branch colored by status, like zsh's [vcs
 
 ## Installation
 
+### From crates.io
+
+```sh
+cargo install git-branch-status
+```
+
+### Prebuilt binaries
+
+Download the archive for your platform from the
+[releases page](https://github.com/akiomik/git-branch-status/releases), extract
+it, and place the `git-branch-status` binary somewhere on your `PATH` (Windows
+builds are distributed as a `.zip`):
+
+```sh
+tar xzf git-branch-status-<version>-<target>.tar.gz
+cp git-branch-status ~/bin
+```
+
+### From source
+
 ```sh
 git clone https://github.com/akiomik/git-branch-status.git && cd git-branch-status
 cargo build --release


### PR DESCRIPTION
## Summary

Building from source is no longer the only way to install. Rework the **Installation** section to cover three options:

1. **From crates.io** — `cargo install git-branch-status`
2. **Prebuilt binaries** — download from the [releases page](https://github.com/akiomik/git-branch-status/releases) and put the binary on `PATH` (Windows builds ship as `.zip`)
3. **From source** — the original `git clone` + `cargo build --release` flow, kept as a fallback

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)