### PR TITLE
chore: release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-29
+
 ### Fixed
 
 - Exit quietly instead of panicking when the branch name or status cannot be
@@ -23,5 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[unreleased]: https://github.com/akiomik/nowhear/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/akiomik/nowhear/releases/tag/v0.1.0
+[unreleased]: https://github.com/akiomik/git-branch-status/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/akiomik/git-branch-status/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/akiomik/git-branch-status/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "git-branch-status"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ansi_term",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-branch-status"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Akiomi Kamakura <akiomik@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
## Summary

Prepare the 0.1.1 release.

- Bump `version` to `0.1.1` in `Cargo.toml` (and `Cargo.lock`).
- Finalize the changelog: move the accumulated entries under `[0.1.1] - 2026-06-29` and add a fresh empty `[Unreleased]` section.
- Fix the changelog comparison links, which pointed at the wrong repository (`nowhear` → `git-branch-status`), and add the `v0.1.1` links.

This release is all bug fixes:

- Exit quietly instead of panicking when the branch name or status cannot be retrieved
- Show the branch name instead of `HEAD (no branch)` on an unborn branch
- Show the original branch name during an apply-backend rebase, instead of the detached commit hash
- Show the tag name when HEAD is detached at a tag, instead of the commit hash

## Verification

- `cargo build`
- `cargo package` succeeds for `git-branch-status v0.1.1` (verification build passes)

## Release steps (after merge)

Tag creation will be done manually. Pushing `v0.1.1` triggers the release workflow (GitHub release + crates.io publish via Trusted Publishing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)