### PR TITLE
chore: enable clippy pedantic lints and fix all warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,14 @@ thiserror = "2.0.18"
 
 [dev-dependencies]
 tempfile = "3"
+
+[lints.clippy]
+cargo = { level = "warn", priority = -1 }
+complexity = { level = "warn", priority = -1 }
+correctness = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+perf = { level = "warn", priority = -1 }
+suspicious = { level = "warn", priority = -1 }
+
+multiple_crate_versions = "allow"

--- a/src/branch_status.rs
+++ b/src/branch_status.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug, PartialEq, Eq, PartialOrd)]
 pub enum BranchStatus {
     NotChanged,
     Staged,

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,38 +35,29 @@ fn main() {
         )
         .get_matches();
 
-    let repo = match Repository::discover(".") {
-        Ok(repo) => repo,
-        Err(_) => std::process::exit(1),
+    let Ok(repo) = Repository::discover(".") else {
+        std::process::exit(1)
     };
 
-    let branch = match repo.branch_name() {
-        Ok(branch) => branch,
-        Err(_) => std::process::exit(1),
+    let Ok(branch) = repo.branch_name() else {
+        std::process::exit(1)
     };
 
-    let status = match repo.branch_status() {
-        Ok(status) => status,
-        Err(_) => std::process::exit(1),
+    let Ok(status) = repo.branch_status() else {
+        std::process::exit(1)
     };
 
     let mode = matches.get_one::<String>("mode").unwrap().as_str();
     match mode {
-        "zsh" => {
-            match status {
-                BranchStatus::NotChanged => print!("%F{{green}}{}%f", branch),
-                BranchStatus::Staged => print!("%F{{yellow}}{}%f", branch),
-                BranchStatus::Unstaged => print!("%F{{red}}{}%f", branch),
-                BranchStatus::Conflicted => print!("%F{{red}}{}%f", branch),
-            };
-        }
-        _ => {
-            match status {
-                BranchStatus::NotChanged => print!("{}", Green.paint(branch)),
-                BranchStatus::Staged => print!("{}", Yellow.paint(branch)),
-                BranchStatus::Unstaged => print!("{}", Red.paint(branch)),
-                BranchStatus::Conflicted => print!("{}", Red.paint(branch)),
-            };
-        }
-    };
+        "zsh" => match status {
+            BranchStatus::NotChanged => print!("%F{{green}}{branch}%f"),
+            BranchStatus::Staged => print!("%F{{yellow}}{branch}%f"),
+            BranchStatus::Unstaged | BranchStatus::Conflicted => print!("%F{{red}}{branch}%f"),
+        },
+        _ => match status {
+            BranchStatus::NotChanged => print!("{}", Green.paint(branch)),
+            BranchStatus::Staged => print!("{}", Yellow.paint(branch)),
+            BranchStatus::Unstaged | BranchStatus::Conflicted => print!("{}", Red.paint(branch)),
+        },
+    }
 }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -60,12 +60,20 @@ pub struct Repository(gix::Repository);
 
 impl Repository {
     /// Discover a repository starting from `path` and walking up to the root.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no git repository is found at or above `path`.
     pub fn discover(path: impl AsRef<Path>) -> Result<Self, Error> {
         Ok(Self(gix::discover(path)?))
     }
 
     /// The branch name to display, optionally suffixed with the in-progress
     /// action (e.g. `main:rebase-i`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HEAD reference cannot be resolved.
     pub fn branch_name(&self) -> Result<String, Error> {
         let head = self.0.head()?;
         let state = self.0.state();
@@ -94,6 +102,11 @@ impl Repository {
     }
 
     /// The worst status across the working tree, ignoring untracked files.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the status iterator cannot be created or yields an
+    /// error while iterating.
     pub fn branch_status(&self) -> Result<BranchStatus, Error> {
         let iter = self
             .0


### PR DESCRIPTION
## Summary

- Add a `[lints.clippy]` table to `Cargo.toml` enabling all major lint groups (`cargo`, `complexity`, `correctness`, `nursery`, `pedantic`, `perf`, `suspicious`), with `multiple_crate_versions` allowed
- Derive `Eq` alongside `PartialEq` on `BranchStatus` to satisfy `clippy::derive_partial_eq_without_eq`
- Rewrite `match`-on-`Result` blocks in `main.rs` with `let`-`else` to satisfy `clippy::match_wildcard_for_single_variants` / readability lints
- Add `# Errors` doc sections to all public fallible methods in `repository.rs` to satisfy `clippy::missing_errors_doc`

## Test plan

- [ ] `cargo clippy` produces no warnings
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)