### PR TITLE
ci: drop OpenSSL setup from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
             use-cross: false
           # aarch64 requires cross-compilation since the host is x86_64. We use cross (Docker-based)
-          # instead of plain cargo because cross's images ship with a pre-built OpenSSL for each
-          # target, eliminating the need to manually set up a cross-compiled OpenSSL environment
-          # that git2 depends on.
+          # instead of plain cargo because its images bundle the aarch64 GNU toolchain (linker and
+          # sysroot), so we don't have to install and configure a cross-linker ourselves.
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use-cross: true
@@ -52,14 +51,6 @@ jobs:
       - name: Add Rust target
         if: "!matrix.use-cross"
         run: rustup target add ${{ matrix.target }}
-
-      # git2 depends on OpenSSL. For native Linux builds we install it explicitly; cross builds
-      # resolve it inside the container; macOS and Windows toolchains handle it automatically.
-      - name: Install system dependencies
-        if: runner.os == 'Linux' && !matrix.use-cross
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev pkg-config
 
       - uses: taiki-e/install-action@v2
         if: matrix.use-cross


### PR DESCRIPTION
## Summary

Since migrating from git2 to gix in #206, the release build no longer depends on OpenSSL/libssl. This PR removes the now-obsolete OpenSSL setup from the release workflow and corrects the stale comments.

## Changes

- **Remove the `Install system dependencies` step.** `git2` linked against OpenSSL, so we installed `libssl-dev`/`pkg-config` for native Linux builds. With the current gix features (`status`, `revision`, `max-performance-safe`, `sha1`) the binary is pure Rust — `zlib-rs` instead of C zlib, no `openssl-sys` in the dependency tree — so this step is no longer needed.
- **Fix the cross usage comment.** It previously claimed cross was chosen because its images ship a pre-built OpenSSL per target. cross is now kept solely because its images bundle the aarch64 GNU toolchain (linker and sysroot), sparing us from installing and configuring a cross-linker by hand.

## Verification

- `cargo tree -i openssl-sys` → no match (OpenSSL fully gone)
- No `git2`/`libgit2`/C deps in the tree; zlib is provided by pure-Rust `zlib-rs`
- The aarch64 `strip` step's `binutils-aarch64-linux-gnu` install is unrelated to OpenSSL and is left untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)