### PR TITLE
perf: enable LTO, codegen-units=1, and strip for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,20 +65,6 @@ jobs:
         if: matrix.use-cross
         run: cross build --release --target ${{ matrix.target }}
 
-      - name: Strip binary (Linux x86_64)
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: strip target/${{ matrix.target }}/release/git-branch-status
-
-      - name: Strip binary (Linux aarch64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get install -y binutils-aarch64-linux-gnu
-          aarch64-linux-gnu-strip target/${{ matrix.target }}/release/git-branch-status
-
-      - name: Strip binary (macOS)
-        if: runner.os == 'macOS'
-        run: strip target/${{ matrix.target }}/release/git-branch-status
-
       - name: Package (Unix)
         if: runner.os != 'Windows'
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,11 @@ clap = "4.6.1"
 gix = { version = "=0.85.0", default-features = false, features = ["status", "revision", "max-performance-safe", "sha1"] }
 thiserror = "2.0.18"
 
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = true
+
 [dev-dependencies]
 tempfile = "3"
 


### PR DESCRIPTION
## Summary

- Add `[profile.release]` to `Cargo.toml` with `lto = "thin"`, `codegen-units = 1`, and `strip = true` to reduce binary size and improve runtime performance of release binaries
- Remove the redundant "Strip binary" steps from the release workflow since Cargo now handles stripping automatically during the build, including cross-compilation targets (aarch64 via the `cross` toolchain)

## Details

`lto = "thin"` enables cross-crate optimizations with a reasonable compile-time cost, which is particularly effective given the large `gix` dependency. `codegen-units = 1` maximizes optimization opportunities. `strip = true` removes all symbols from the binary.

Cargo's built-in strip selects the appropriate tool per target (e.g. `aarch64-linux-gnu-strip` for the cross-compiled Linux aarch64 target), so the three explicit strip steps — including the `apt-get install binutils-aarch64-linux-gnu` call — are no longer needed.

## Test plan

- [ ] Trigger a test release (e.g. `test-release-*` tag) and confirm all target binaries are stripped correctly
- [ ] Verify binary sizes are reduced compared to the previous release

🤖 Generated with [Claude Code](https://claude.com/claude-code)