### PR TITLE
feat: add optional DIR argument to specify repository path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Accept an optional `[DIR]` positional argument to specify the git repository
+  path (e.g. `git-branch-status --mode zsh /path/to/repo`). Defaults to `.`
+  when omitted, preserving the previous behavior.
+
 ### Changed
 
 - Replace the libgit2 (`git2`) backend with the pure-Rust `gix` (gitoxide). This

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@
 
 extern crate clap;
 
+use std::path::PathBuf;
+
 use ansi_term::Colour::{Green, Red, Yellow};
 use clap::{Arg, Command};
 
@@ -33,9 +35,18 @@ fn main() {
                 .value_parser(["zsh", "stdout"])
                 .help("Sets a mode"),
         )
+        .arg(
+            Arg::new("dir")
+                .value_name("DIR")
+                .value_hint(clap::ValueHint::DirPath)
+                .value_parser(clap::value_parser!(PathBuf))
+                .default_value(".")
+                .help("Path to the git repository (default: current directory)"),
+        )
         .get_matches();
 
-    let Ok(repo) = Repository::discover(".") else {
+    let dir = matches.get_one::<PathBuf>("dir").unwrap();
+    let Ok(repo) = Repository::discover(dir) else {
         std::process::exit(1)
     };
 


### PR DESCRIPTION
## Summary

- Add an optional `[DIR]` positional argument so users can run `git-branch-status [--mode zsh] /path/to/repo` without changing the working directory
- Use `PathBuf` instead of `String` for the argument type, enabling non-UTF-8 path support
- Add `ValueHint::DirPath` to improve tab-completion in generated shell completions

## Test plan

- [x] `git-branch-status` (no args) behaves as before
- [x] `git-branch-status .` produces the same output
- [x] `git-branch-status /path/to/other/repo` shows status of the specified repository
- [x] `git-branch-status --mode zsh /path/to/repo` produces zsh-formatted output for the specified repository
- [x] `git-branch-status --help` shows `[DIR]` in the usage line with correct description

🤖 Generated with [Claude Code](https://claude.com/claude-code)