### PR TITLE
perf: disable rename detection in status detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Speed up status detection by short-circuiting the worktree scan. Conflicts are
   now detected from the index up front, and the scan stops at the first unstaged
   change instead of always walking the entire worktree.
+- Disable rename detection during status detection. It read blob contents to
+  compute similarity without affecting the reported status, so turning it off
+  removes that overhead.
 
 ## [0.2.0] - 2026-06-30
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -23,6 +23,7 @@ use gix::refs::FullNameRef;
 use gix::state::InProgress;
 use gix::status::index_worktree::Item as IndexWorktreeItem;
 use gix::status::plumbing::index_as_worktree::EntryStatus;
+use gix::status::tree_index::TrackRenames;
 use gix::status::{Item as StatusItem, UntrackedFiles};
 
 use crate::branch::Status;
@@ -93,6 +94,11 @@ impl Repository {
             .0
             .status(Discard)?
             .untracked_files(UntrackedFiles::None)
+            // Rename detection (on by default) reads blob contents to compute
+            // similarity, which is pure overhead here: a rename maps to the same
+            // staged/unstaged status as a separate delete and add would.
+            .index_worktree_rewrites(None)
+            .tree_index_track_renames(TrackRenames::Disabled)
             .into_iter(Vec::<BString>::new())?;
 
         // With conflicts ruled out, an unstaged change is the worst remaining
@@ -119,7 +125,8 @@ impl Repository {
                     // Stat-only refresh or `--intent-to-add`: nothing changed.
                     EntryStatus::NeedsUpdate(_) | EntryStatus::IntentToAdd => {}
                 },
-                // A rename detected against the index counts as unstaged.
+                // Rewrites are disabled above, but were one to slip through it
+                // would still be an unstaged worktree change.
                 StatusItem::IndexWorktree(IndexWorktreeItem::Rewrite { .. }) => {
                     return Ok(Status::Unstaged);
                 }


### PR DESCRIPTION
## Summary

Rename (rewrite) tracking is enabled by default in `gix` for both the tree↔index and index↔worktree comparisons. Detecting renames reads blob contents to compute file similarity, which is pure overhead for this tool: a rename produces the same staged/unstaged `Status` as a separate delete plus add would.

This disables rename detection on both comparisons:

- `index_worktree_rewrites(None)`
- `tree_index_track_renames(TrackRenames::Disabled)`

The reported `Status` is unaffected.

> Stacked on top of #230 (base branch `perf-short-circuit-branch-status`); will retarget to `main` once that merges.

## Tests

`just test`, `just lint`, and `just fmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7T285VENQejFzhds81LxG