### PR TITLE
refactor: make branch status precedence explicit

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -12,7 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
+/// The worst change present in the working tree.
+///
+/// In increasing order of severity: `Conflicted` > `Unstaged` > `Staged` >
+/// `NotChanged`. This precedence is a domain decision applied explicitly by
+/// [`Repository::branch_status`](crate::repository::Repository::branch_status),
+/// not derived from this declaration order, so the variants can be reordered
+/// freely without changing behavior.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Status {
     NotChanged,
     Staged,

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -107,12 +107,9 @@ impl Repository {
         let mut status = Status::NotChanged;
         for item in iter {
             match item? {
-                // HEAD <-> index: a staged change.
-                StatusItem::TreeIndex(_) => {
-                    if Status::Staged > status {
-                        status = Status::Staged;
-                    }
-                }
+                // HEAD <-> index: a staged change. Unstaged changes short-circuit
+                // above, so staged is the highest status this loop can settle on.
+                StatusItem::TreeIndex(_) => status = Status::Staged,
                 // index <-> worktree: an unstaged change.
                 StatusItem::IndexWorktree(IndexWorktreeItem::Modification {
                     status: entry,


### PR DESCRIPTION
## Summary

`Status` derived `PartialOrd`, which silently encoded the severity precedence (`Conflicted > Unstaged > Staged > NotChanged`) in the variant declaration order. `branch_status` relied on that order via `if next > status`, so reordering the variants would have quietly changed behavior — a maintenance footgun.

With the worktree scan now short-circuiting on conflicts and unstaged changes (#230), the loop only ever needs to decide between `Staged` and `NotChanged`, so the ordering dependency is no longer needed. This change:

- drops the derived `PartialOrd` from `Status`,
- applies the precedence explicitly in `branch_status` (conflicts and unstaged changes short-circuit; staged otherwise),
- documents the precedence as a domain decision in the `Status` doc comment.

Behavior is unchanged.

> Stacked on top of #231 (base branch `perf-disable-rename-detection`); will retarget to `main` once the chain merges.

## Tests

`just test`, `just lint`, and `just fmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7T285VENQejFzhds81LxG