### PR TITLE
refactor: avoid cloning the branch name when formatting

### DIFF
--- a/src/mode.rs
+++ b/src/mode.rs
@@ -30,7 +30,7 @@ impl Mode {
             Status::Staged => Yellow,
             Status::Unstaged | Status::Conflicted => Red,
         };
-        format!("{}", color.paint(branch.name.clone()))
+        format!("{}", color.paint(branch.name.as_str()))
     }
 
     fn format_zsh(branch: &Branch) -> String {


### PR DESCRIPTION
## Summary

`ansi_term`'s `Colour::paint` accepts a borrowed string, so the owned `branch.name.clone()` in the stdout formatter is unnecessary. Pass `branch.name.as_str()` instead.

Independent of the status-detection PRs; touches only `mode.rs`.

## Tests

`just test`, `just lint`, and `just fmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7T285VENQejFzhds81LxG