### PR TITLE
fix: escape % in branch names for zsh prompt output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Escape `%` characters in branch names when formatting for zsh (`--mode zsh`).
+  Without this, a branch named e.g. `feature/%n` would cause zsh to expand `%n`
+  to the login name inside `$PROMPT`, producing incorrect output.
+
 ## [0.2.1] - 2026-06-30
 
 ### Changed

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -39,7 +39,8 @@ impl Mode {
             Status::Staged => "yellow",
             Status::Unstaged | Status::Conflicted => "red",
         };
-        format!("%F{{{color}}}{}%f", branch.name)
+        let name = branch.name.replace('%', "%%");
+        format!("%F{{{color}}}{name}%f")
     }
 
     #[must_use]
@@ -133,5 +134,25 @@ mod tests {
         };
         let actual = Mode::Zsh.format(&branch);
         assert_eq!(actual, "%F{red}main%f");
+    }
+
+    #[test]
+    fn test_zsh_escapes_percent_in_branch_name() {
+        let branch = Branch {
+            name: "feature/%n".to_owned(),
+            status: Status::NotChanged,
+        };
+        let actual = Mode::Zsh.format(&branch);
+        assert_eq!(actual, "%F{green}feature/%%n%f");
+    }
+
+    #[test]
+    fn test_zsh_escapes_trailing_percent_in_branch_name() {
+        let branch = Branch {
+            name: "main%".to_owned(),
+            status: Status::NotChanged,
+        };
+        let actual = Mode::Zsh.format(&branch);
+        assert_eq!(actual, "%F{green}main%%%f");
     }
 }


### PR DESCRIPTION
## Summary

- Branch names containing `%` were passed verbatim into the zsh prompt format string (`%F{color}<name>%f`).
- Zsh expands prompt sequences such as `%n` (login name), `%~` (working directory), and `%j` (job count), so a branch like `feature/%n` would display the username instead of the literal name, and a trailing `%` could break the closing `%f` color-reset token.
- Fix: replace every `%` in the branch name with `%%` before embedding it in the format string.

## Test plan

- [x] `test_zsh_escapes_percent_in_branch_name` — verifies `feature/%n` → `%F{green}feature/%%n%f`
- [x] `test_zsh_escapes_trailing_percent_in_branch_name` — verifies `main%` → `%F{green}main%%%f`
- [x] All existing zsh tests continue to pass
- [x] `just fmt` — no changes
- [x] `just lint` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)