### PR TITLE
fix: ignore empty head-name file during rebase branch name detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Escape `%` characters in branch names when formatting for zsh (`--mode zsh`).
   Without this, a branch named e.g. `feature/%n` would cause zsh to expand `%n`
   to the login name inside `$PROMPT`, producing incorrect output.
+- Ignore an empty or whitespace-only `rebase-merge/head-name` or
+  `rebase-apply/head-name` file instead of returning an empty branch name.
+  A partially-written or corrupted file now falls back to the real HEAD.
 
 ## [0.2.1] - 2026-06-30
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -154,7 +154,9 @@ impl Repository {
             let path = git_dir.join(dir).join("head-name");
             if let Ok(content) = fs::read_to_string(&path) {
                 let refname = content.trim();
-                return Some(self.shorthand_of_ref(refname));
+                if !refname.is_empty() {
+                    return Some(self.shorthand_of_ref(refname));
+                }
             }
         }
         None
@@ -340,6 +342,28 @@ mod tests {
             .write_str("refs/heads/feature\n")?;
         dir.child(".git/rebase-apply/rebasing").touch()?;
         assert_eq!(open(&dir)?.branch_name()?, "feature:rebase");
+        dir.close().map_err(Into::into)
+    }
+
+    #[test]
+    fn branch_name_ignores_empty_rebase_merge_head_name() -> Result<()> {
+        let dir = init_repo()?;
+        // An empty head-name file (e.g. from a partial write or filesystem
+        // corruption) must not override HEAD: the tool should fall back to the
+        // real symbolic HEAD ("main") rather than returning "" or ":rebase-i".
+        dir.child(".git/rebase-merge/head-name").write_str("")?;
+        dir.child(".git/rebase-merge/interactive").touch()?;
+        assert_eq!(open(&dir)?.branch_name()?, "main:rebase-i");
+        dir.close().map_err(Into::into)
+    }
+
+    #[test]
+    fn branch_name_ignores_whitespace_only_rebase_apply_head_name() -> Result<()> {
+        let dir = init_repo()?;
+        dir.child(".git/rebase-apply/head-name")
+            .write_str("   \n")?;
+        dir.child(".git/rebase-apply/rebasing").touch()?;
+        assert_eq!(open(&dir)?.branch_name()?, "main:rebase");
         dir.close().map_err(Into::into)
     }
 


### PR DESCRIPTION
## Summary

- `rebase_head_name()` read `rebase-merge/head-name` or `rebase-apply/head-name` and passed the trimmed content directly to `shorthand_of_ref()` without checking whether the result was empty.
- An empty or whitespace-only file (e.g. from a partial write or filesystem corruption during a rebase) caused `branch_name()` to return `""` or `":rebase-i"` instead of falling back to the real HEAD.
- Fix: add an `is_empty()` guard — a blank file is now treated as absent, and the normal HEAD resolution path is used.

## Test plan

- [x] `branch_name_ignores_empty_rebase_merge_head_name` — empty `rebase-merge/head-name` + interactive marker → falls back to `"main:rebase-i"`
- [x] `branch_name_ignores_whitespace_only_rebase_apply_head_name` — whitespace-only `rebase-apply/head-name` + rebasing marker → falls back to `"main:rebase"`
- [x] All existing rebase tests continue to pass (non-empty files still work)
- [x] `just fmt` — no changes
- [x] `just lint` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)