### PR TITLE
docs: clarify intentional silent failure and non-deterministic tag selection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,10 @@ fn main() {
 
     match run(cli) {
         Ok(output) => print!("{output}"),
+        // Intentionally silent: any output on stderr would appear in the
+        // terminal when this tool is invoked inside a shell prompt via $().
+        // A non-zero exit code is the only signal we can emit without
+        // polluting the prompt.
         Err(_) => exit(1),
     }
 }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -173,6 +173,11 @@ impl Repository {
     }
 
     /// A tag pointing exactly at HEAD, behaving like `git describe --exact-match`.
+    ///
+    /// When multiple tags point to the same commit the choice is made by gix
+    /// internals (annotated tags before lightweight, then reverse-alphabetical
+    /// by name). This matches `git describe --exact-match` behaviour, which
+    /// also does not guarantee a stable winner among ties.
     fn tag_name(&self) -> Option<String> {
         let commit = self.0.head_commit().ok()?;
         let format = commit


### PR DESCRIPTION
## Summary

Adds comments at two locations identified during code review where the behaviour is correct but not immediately obvious to a future reader.

- **`src/main.rs`** — `Err(_) => exit(1)`: stderr is suppressed by design. Any output on stderr would appear in the terminal when the tool is called inside a shell prompt via `$()`. A non-zero exit code is the only signal available without polluting the prompt.

- **`src/repository.rs`** — `tag_name()`: when multiple tags point to the same commit, the winner is chosen by gix internals (annotated before lightweight, then reverse-alphabetical by name). This matches `git describe --exact-match`, which has the same tie-breaking behaviour and is therefore accepted as-is.

## Test plan

- [x] `just fmt` — no changes
- [x] `just lint` — no warnings
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)