### PR TITLE
fix: strip refs/remotes/ and refs/tags/ in shorthand_of_ref fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ApplyMailboxRebase`). Reading it unconditionally could silently suppress the
   action label or show a stale name from a previous rebase. When a rebase is
   active but the file is absent, the display now falls back to HEAD gracefully.
+- When a ref recorded in `head-name` cannot be found in the repository (e.g.
+  the branch was deleted mid-rebase), the shorthand fallback now strips
+  `refs/remotes/` and `refs/tags/` in addition to `refs/heads/`, instead of
+  returning the full ref name verbatim.
 
 ## [0.2.1] - 2026-06-30
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -197,15 +197,19 @@ impl Repository {
     }
 
     /// Resolve a full ref name to its shorthand, prettifying via the ref store
-    /// when possible and otherwise stripping the `refs/heads/` prefix.
+    /// when possible and otherwise stripping the well-known namespace prefix.
     fn shorthand_of_ref(&self, refname: &str) -> String {
         if let Ok(reference) = self.0.find_reference(refname) {
             return reference.name().shorten().to_string();
         }
-        refname
-            .strip_prefix("refs/heads/")
-            .unwrap_or(refname)
-            .to_string()
+        // Ref not found (e.g. branch deleted mid-rebase): strip the namespace
+        // prefix as a best-effort shorthand.
+        for prefix in ["refs/heads/", "refs/remotes/", "refs/tags/"] {
+            if let Some(short) = refname.strip_prefix(prefix) {
+                return short.to_string();
+            }
+        }
+        refname.to_string()
     }
 
     fn shorthand(name: &FullNameRef) -> String {
@@ -368,6 +372,29 @@ mod tests {
         dir.child(".git/rebase-apply/head-name")
             .write_str("refs/heads/feature\n")?;
         assert_eq!(open(&dir)?.branch_name()?, "feature:am/rebase");
+        dir.close().map_err(Into::into)
+    }
+
+    #[test]
+    fn branch_name_shortens_remote_ref_from_head_name_when_ref_not_found() -> Result<()> {
+        let dir = init_repo()?;
+        // head-name records a remote-tracking ref; the remote does not exist in
+        // this repo so find_reference fails. The fallback must strip
+        // "refs/remotes/" rather than returning the full ref verbatim.
+        dir.child(".git/rebase-apply/head-name")
+            .write_str("refs/remotes/origin/main\n")?;
+        assert_eq!(open(&dir)?.branch_name()?, "origin/main:am/rebase");
+        dir.close().map_err(Into::into)
+    }
+
+    #[test]
+    fn branch_name_shortens_tag_ref_from_head_name_when_ref_not_found() -> Result<()> {
+        let dir = init_repo()?;
+        // head-name records a tag ref that does not exist in this repo;
+        // the fallback must strip "refs/tags/" rather than returning the full ref.
+        dir.child(".git/rebase-apply/head-name")
+            .write_str("refs/tags/v1.0.0\n")?;
+        assert_eq!(open(&dir)?.branch_name()?, "v1.0.0:am/rebase");
         dir.close().map_err(Into::into)
     }
 


### PR DESCRIPTION
## Summary

When `find_reference()` fails for a ref recorded in `head-name` (e.g. the branch was deleted mid-rebase), `shorthand_of_ref()` fell back to stripping only the `refs/heads/` prefix. A `refs/remotes/` or `refs/tags/` ref was returned verbatim (e.g. `"refs/remotes/origin/main:rebase"`).

Extend the fallback to try all three well-known namespace prefixes in order:
- `refs/heads/feature` → `feature` (unchanged)
- `refs/remotes/origin/main` → `origin/main` (was returned verbatim)
- `refs/tags/v1.0.0` → `v1.0.0` (was returned verbatim)

Refs with unknown namespaces still return the full path (no worse than before).

## Test plan

- [x] `branch_name_shortens_remote_ref_from_head_name_when_ref_not_found` — `refs/remotes/origin/main` in head-name → `"origin/main:am/rebase"`
- [x] `branch_name_shortens_tag_ref_from_head_name_when_ref_not_found` — `refs/tags/v1.0.0` in head-name → `"v1.0.0:am/rebase"`
- [x] All existing tests pass (34 total)
- [x] `just fmt` — no changes
- [x] `just lint` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)