### PR TITLE
fix: assert rewrite items are never emitted when rewrites are disabled

### DIFF
--- a/src/repository.rs
+++ b/src/repository.rs
@@ -132,9 +132,14 @@ impl Repository {
                     // Stat-only refresh or `--intent-to-add`: nothing changed.
                     EntryStatus::NeedsUpdate(_) | EntryStatus::IntentToAdd => {}
                 },
-                // Rewrites are disabled above, but were one to slip through it
-                // would still be an unstaged worktree change.
+                // Rewrites are disabled above. The debug assertion catches any
+                // future gix version that emits them despite the opt-out, while
+                // the return keeps release builds correct if one slips through.
                 StatusItem::IndexWorktree(IndexWorktreeItem::Rewrite { .. }) => {
+                    debug_assert!(
+                        false,
+                        "index_worktree_rewrites(None) is set; a Rewrite item should never be emitted"
+                    );
                     return Ok(Status::Unstaged);
                 }
                 // Untracked entries are excluded by `UntrackedFiles::None`.


### PR DESCRIPTION
## Summary

`branch_status()` disables rewrite detection with `index_worktree_rewrites(None)`, making the `IndexWorktreeItem::Rewrite` match arm unreachable in practice. The arm silently returned `Status::Unstaged`, which is the correct fallback but hides any future gix version that starts emitting rewrite items despite the opt-out.

Add a `debug_assert!(false, …)` so that test and debug builds panic immediately if the invariant is ever violated, while release builds keep the safe `Status::Unstaged` return.

## Test plan

- [x] All existing tests pass (34 total) — confirms the arm is never reached under current gix behavior
- [x] `just fmt` — no changes
- [x] `just lint` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)