### PR TITLE
fix: pass gpgsign=false flags to git_stdout test helper

### DIFF
--- a/src/repository.rs
+++ b/src/repository.rs
@@ -266,9 +266,11 @@ mod tests {
     }
 
     fn git_stdout(dir: &Path, args: &[&str]) -> Result<String> {
+        let mut full = vec!["-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false"];
+        full.extend_from_slice(args);
         let cmd = Command::new("git")
             .current_dir(dir)
-            .args(args)
+            .args(&full)
             .assert()
             .success();
         let out = cmd.get_output().to_owned();


### PR DESCRIPTION
## Summary

The `git_stdout` test helper was missing the `-c commit.gpgsign=false` and `-c tag.gpgsign=false` flags that the `git` helper prepends to every fixture command. On machines or CI environments where GPG signing is enabled globally, any future write command run through `git_stdout` would fail or produce unexpected output.

Align `git_stdout` with `git` by prepending the same signing-suppression flags. Current callers (`rev-parse`, `merge-base`) are read-only and unaffected; this is a defensive fix for future use.

## Test plan

- [x] All existing tests pass (34 total)
- [x] `just fmt` — no changes
- [x] `just lint` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)