### PR TITLE
refactor: remove unused PartialOrd derive from Mode

### DIFF
--- a/src/mode.rs
+++ b/src/mode.rs
@@ -17,7 +17,7 @@ use clap::ValueEnum;
 
 use crate::branch::{Branch, Status};
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, ValueEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
 pub enum Mode {
     Stdout,
     Zsh,


### PR DESCRIPTION
## Summary

`Mode` derived `PartialOrd` but the ordering was never used anywhere in the codebase. The derived declaration-order comparison (`Stdout < Zsh`) carries no semantic meaning. Keeping it as a public trait impl would silently constrain future variant ordering (inserting a new variant between them would change the comparison result without any obvious signal).

## Test plan

- [x] All existing tests pass (34 total)
- [x] `just fmt` — no changes
- [x] `just lint` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)